### PR TITLE
fixed error HashWithIndifferentAccess

### DIFF
--- a/lib/middleman-metaman/helpers.rb
+++ b/lib/middleman-metaman/helpers.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/hash/indifferent_access"
+
 module Middleman
   module Metaman
     module Helpers


### PR DESCRIPTION
fixed : uninitialized constant ActiveSupport::HashWithIndifferentAccess error
should be explicitly required in helpers.rb